### PR TITLE
chore: enable AGP 9 newDsl

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     alias(libs.plugins.firebase.crashlytics)
     alias(libs.plugins.firebase.performance)
     alias(libs.plugins.convention.jacoco)
-    alias(libs.plugins.androidx.baselineprofile)
+    // alias(libs.plugins.androidx.baselineprofile)
 }
 
 configure<ApplicationExtension> {
@@ -39,7 +39,7 @@ dependencies {
     implementation(project(Modules.LPA_DATA))
     implementation(project(Modules.LPA_DOMAIN))
     implementation(project(Modules.LPA_PRESENTATION))
-    "baselineProfile"(project(Modules.BASELINE_PROFILE))
+    // "baselineProfile"(project(Modules.BASELINE_PROFILE)) // Check baseline build.gradle for more info.
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -2,7 +2,12 @@ import com.android.build.api.dsl.ManagedVirtualDevice
 
 plugins {
     alias(libs.plugins.android.test)
-    alias(libs.plugins.androidx.baselineprofile)
+    /*
+     The performance gains will be conserved,
+     this plugin is used to generate the baseline-prof.txt file and not to use it per se.
+     I'm commenting this due to no support for AGP 9 newDsl=true is not supported right now.
+     */
+    // alias(libs.plugins.androidx.baselineprofile)
 }
 
 android {
@@ -41,10 +46,10 @@ android {
 
 // This is the configuration block for the Baseline Profile plugin.
 // You can specify to run the generators on a managed devices or connected devices.
-baselineProfile {
-    managedDevices += "pixel6Api34"
-    useConnectedDevices = false
-}
+// baselineProfile {
+//     managedDevices += "pixel6Api34"
+//     useConnectedDevices = false
+// }
 
 dependencies {
     implementation(libs.androidx.benchmark.macro.junit4)

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,9 +35,7 @@ android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
 android.r8.optimizedResourceShrinking=true
-# AGP9 not fully compatible with Sonar right now, newDsl will stay false for the time being.
-# https://community.sonarsource.com/t/working-towards-the-support-of-android-gradle-plugin-9/177015
-android.newDsl=false
+android.newDsl=true
 android.dependency.excludeLibraryComponentsFromConstraints=false
 android.generateSyncIssueWhenLibraryConstraintsAreEnabled=false
 android.enableR8.fullMode=true


### PR DESCRIPTION
- Set `android.newDsl=true` in `gradle.properties`.
- Comment out the `androidx.baselineprofile` plugin and related configurations in the `app` and `baselineprofile` modules due to lack of support for the new DSL.