### PR TITLE
chore: bump version to 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+#### 24/05/2026 - v0.1.6
+- feat: offline first approach to stops screens.
+- feat: new empty messages in favorite stops tab.
+- chore: baseline profile to increase startup time.
+- chore: firebase lazy initialization.
+- chore: firebase performance.
+- chore: AGP 9 compatibility.
+- chore: migration from moshi to kotlin serialization.
+- update: sonar.
+
 #### 02/02/2026 - v0.1.4
 - feat: conventional plugins.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ## Wawas amarillo limón.
 
 ### Project Status:
-[AGP 9 breaks the scanner at the moment, I will update it when a fix comes by 💛💙](https://community.sonarsource.com/t/working-towards-the-support-of-android-gradle-plugin-9/177015/4)
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=AbrahamCardenes_WawaAmarillaLimon&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=AbrahamCardenes_WawaAmarillaLimon)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=AbrahamCardenes_WawaAmarillaLimon&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=AbrahamCardenes_WawaAmarillaLimon)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 projectTargetSdkVersion = "36"
 projectCompileSdkVersion = "36"
 projectMinSdkVersion = "24"
-projectVersionCode = "11"
-projectVersionName = "0.1.5"
+projectVersionCode = "12"
+projectVersionName = "0.1.6"
 projectApplicationId = "com.abrahamcardenes.wawaamarillalimon"
 
 agp = "9.2.1"


### PR DESCRIPTION
- Increment `projectVersionCode` to `12` and `projectVersionName` to `0.1.6` in `libs.versions.toml`.
- Update `CHANGELOG.md` with release notes for v0.1.6, including offline-first stops, Moshi to Kotlin Serialization migration, and AGP 9 compatibility.
- Remove the AGP 9 scanner warning from `README.md`.