### PR TITLE
refactor: inject DispatchersProvider into BusStopsRepositoryImpl

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 projectTargetSdkVersion = "37"
 projectCompileSdkVersion = "37"
 projectMinSdkVersion = "24"
-projectVersionCode = "13"
-projectVersionName = "0.1.8"
+projectVersionCode = "14"
+projectVersionName = "0.1.9"
 projectApplicationId = "com.abrahamcardenes.wawaamarillalimon"
 
 agp = "9.3.1"

--- a/lpa_data/src/main/java/com/abrahamcardenes/lpa_data/data/BusStopsRepositoryImpl.kt
+++ b/lpa_data/src/main/java/com/abrahamcardenes/lpa_data/data/BusStopsRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.abrahamcardenes.lpa_data.data
 
+import com.abrahamcardenes.core.dispatchers.DispatchersProvider
 import com.abrahamcardenes.core.network.DataError
 import com.abrahamcardenes.core.network.EmptyResult
 import com.abrahamcardenes.core.network.Result
@@ -24,29 +25,35 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import okhttp3.Headers
 
 class BusStopsRepositoryImpl(
     private val api: ApiParadas,
     private val busStopDao: BusStopDao,
     private val crashlyticsService: CrashlyticsService,
-    private val wawaSettings: WawaSettings
+    private val wawaSettings: WawaSettings,
+    private val dispatchersProvider: DispatchersProvider
 ) : BusStopsRepository {
 
-    override suspend fun getBusStops(): EmptyResult<DataError> = safecall {
-        val paradasResponse = api.getParadas(etag = wawaSettings.getEtag() ?: "")
-        if (paradasResponse.code() == 304) return Result.Success(Unit)
-        saveEtag(headers = paradasResponse.headers())
-        paradasResponse
-    }.map { busStopDto ->
-        val originalBusStops = busStopDto.toMutableList()
-        originalBusStops.removeIf { it.stopNumber == "PAR" || it.addressName == "NOMBRE" }
-        val busStopsFromApi = originalBusStops.toDomain()
-        val uniqueBusStops = busStopsFromApi.distinctBy { it.stopNumber }
-            .sortedBy { it.stopNumber }
-        busStopDao.upsertAll(uniqueBusStops.map { it.toEntity() })
-    }.onError { error ->
-        crashlyticsService.logException(Exception(error.toString()))
+    override suspend fun getBusStops(): EmptyResult<DataError> = withContext(
+        dispatchersProvider.IO
+    ) {
+        safecall {
+            val paradasResponse = api.getParadas(etag = wawaSettings.getEtag() ?: "")
+            if (paradasResponse.code() == 304) return@withContext Result.Success(Unit)
+            saveEtag(headers = paradasResponse.headers())
+            paradasResponse
+        }.map { busStopDto ->
+            val originalBusStops = busStopDto.toMutableList()
+            originalBusStops.removeIf { it.stopNumber == "PAR" || it.addressName == "NOMBRE" }
+            val busStopsFromApi = originalBusStops.toDomain()
+            val uniqueBusStops = busStopsFromApi.distinctBy { it.stopNumber }
+                .sortedBy { it.stopNumber }
+            busStopDao.upsertAll(uniqueBusStops.map { it.toEntity() })
+        }.onError { error ->
+            crashlyticsService.logException(Exception(error.toString()))
+        }
     }
 
     private suspend fun saveEtag(headers: Headers) {

--- a/lpa_data/src/main/java/com/abrahamcardenes/lpa_data/di/busStops/BusStopsRepositoryModule.kt
+++ b/lpa_data/src/main/java/com/abrahamcardenes/lpa_data/di/busStops/BusStopsRepositoryModule.kt
@@ -1,5 +1,6 @@
 package com.abrahamcardenes.lpa_data.di.busStops
 
+import com.abrahamcardenes.core.dispatchers.DispatchersProvider
 import com.abrahamcardenes.core_android.dataStore.WawaSettings
 import com.abrahamcardenes.core_android.firebase.CrashlyticsService
 import com.abrahamcardenes.core_db.BusStopDao
@@ -21,11 +22,13 @@ object BusStopsRepositoryModule {
         api: ApiParadas,
         dao: BusStopDao,
         crashlyticsService: CrashlyticsService,
-        wawaSettings: WawaSettings
+        wawaSettings: WawaSettings,
+        dispatchersProvider: DispatchersProvider
     ): BusStopsRepository = BusStopsRepositoryImpl(
         api = api,
         busStopDao = dao,
         crashlyticsService = crashlyticsService,
-        wawaSettings = wawaSettings
+        wawaSettings = wawaSettings,
+        dispatchersProvider = dispatchersProvider
     )
 }

--- a/lpa_data/src/test/java/com/abrahamcardenes/lpa_data/BusStopsRepositoryImplTest.kt
+++ b/lpa_data/src/test/java/com/abrahamcardenes/lpa_data/BusStopsRepositoryImplTest.kt
@@ -15,6 +15,7 @@ import com.abrahamcardenes.lpa_data.jsons.mockedBusStopDetailWithLessTime
 import com.abrahamcardenes.lpa_data.jsons.ogs.shortOriginalReplication
 import com.abrahamcardenes.lpa_data.remote.apis.ApiParadas
 import com.abrahamcardenes.lpa_data.utils.ServerMocks
+import com.abrahamcardenes.lpa_data.utils.TestsDispatchers
 import com.abrahamcardenes.lpa_domain.models.busStops.BusLine
 import com.abrahamcardenes.lpa_domain.models.busStops.BusStop
 import com.google.common.truth.Truth.assertThat
@@ -55,7 +56,8 @@ class BusStopsRepositoryImplTest {
             api = apiParadas,
             busStopDao = busStopDao,
             crashlyticsService = crashlyticsService,
-            wawaSettings = wawaSettings
+            wawaSettings = wawaSettings,
+            dispatchersProvider = TestsDispatchers
         )
     }
 

--- a/lpa_data/src/test/java/com/abrahamcardenes/lpa_data/utils/TestsDispatchers.kt
+++ b/lpa_data/src/test/java/com/abrahamcardenes/lpa_data/utils/TestsDispatchers.kt
@@ -1,0 +1,16 @@
+package com.abrahamcardenes.lpa_data.utils
+
+import com.abrahamcardenes.core.dispatchers.DispatchersProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+
+@OptIn(ExperimentalCoroutinesApi::class)
+object TestsDispatchers : DispatchersProvider {
+    override val IO: CoroutineDispatcher
+        get() = UnconfinedTestDispatcher()
+    override val Main: CoroutineDispatcher
+        get() = UnconfinedTestDispatcher()
+    override val Default: CoroutineDispatcher
+        get() = UnconfinedTestDispatcher()
+}


### PR DESCRIPTION
- Update `BusStopsRepositoryImpl` to use `dispatchersProvider.IO` for network and database operations in `getBusStops`.